### PR TITLE
Enable *warn-on-reflection* and add missing hints

### DIFF
--- a/src/s_exp/hirundo/utils.clj
+++ b/src/s_exp/hirundo/utils.clj
@@ -1,6 +1,8 @@
 (ns s-exp.hirundo.utils
   (:require [clojure.string :as str]))
 
+(set! *warn-on-reflection* true)
+
 (defn camel->dashed
   [s]
   (-> s


### PR DESCRIPTION
At the moment there are several reflection calls occuring on the hot-path for request handling. This is both slow and makes it harder to compile with GraalVM.

This commit enables the `*warn-on-reflection*` global on all namespaces and adds the missing type hints to locations where reflection were occuring.

In some cases this required restructuring code a bit to better apply the hints.