### PR TITLE
Use HeaderNames/create to support http/2

### DIFF
--- a/src/s_exp/hirundo/http/response.clj
+++ b/src/s_exp/hirundo/http/response.clj
@@ -41,7 +41,7 @@
       (.send server-response o))))
 
 (defn header-name ^HeaderName [ring-header-name]
-  (HeaderNames/createFromLowercase (name ring-header-name)))
+  (HeaderNames/create (name ring-header-name)))
 
 (defn set-headers!
   [^ServerResponse server-response headers]


### PR DESCRIPTION
When handling an http/2 request hirundo requests will fail with a PROTOCOL_ERROR if the response contains upper-case header names.

This fixes the issue by using HeaderNames/create which automatically lower-cases the given header name.