### PR TITLE
Add :authority to request object

### DIFF
--- a/src/s_exp/hirundo/http/request.clj
+++ b/src/s_exp/hirundo/http/request.clj
@@ -63,6 +63,7 @@
                        :protocol (ring-protocol (.prologue server-request))
                        :request-method (ring-method (.prologue server-request))
                        :headers (ring-headers (.headers server-request))
+                       :authority (.authority server-request)
                        ::server-request server-request
                        ::server-response server-response})
 


### PR DESCRIPTION
On http/2 the request header "host" is not available - instead it is intended that the authority property is used. Halidon does populate the authority field in both http/1.1 and http/2 so it's a stable field that can be references accross both.